### PR TITLE
Add pre-commit and saturating addsub example.

### DIFF
--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -1,4 +1,4 @@
-name: run pre-commit tool
+name: CI Testing
 
 on:
   pull_request:

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -24,7 +24,35 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Fetch latest XLSynth release
+        id: fetch-xlsynth
+        run: |
+          API_URL="https://api.github.com/repos/xlsynth/xlsynth/releases/latest"
+          RESPONSE=$(curl -s $API_URL)
+          BINARY_URL=$(echo $RESPONSE | jq -r '.assets[] | select(.name == "dslx_interpreter_main-ubuntu2204") | .browser_download_url')
+          STDLIB_URL=$(echo $RESPONSE | jq -r '.assets[] | select(.name == "dslx_stdlib.tar.gz") | .browser_download_url')
+          if [ -z "$BINARY_URL" ] || [ -z "$STDLIB_URL" ]; then
+            echo "Error: Could not find required assets in the latest release." >&2
+            exit 1
+          fi
+          echo "BINARY_URL=$BINARY_URL" >> $GITHUB_ENV
+          echo "STDLIB_URL=$STDLIB_URL" >> $GITHUB_ENV
+
+      - name: Download DSLX interpreter binary
+        run: |
+          curl -L "$BINARY_URL" -o dslx_interpreter_main
+          chmod +x dslx_interpreter_main
+
+      - name: Download and extract DSLX standard library
+        run: |
+          curl -L "$STDLIB_URL" -o dslx_stdlib.tar.gz
+          tar -xzf dslx_stdlib.tar.gz
+          export DSLX_STDLIB_PATH=$PWD/xls/dslx/stdlib
+          echo "DSLX_STDLIB_PATH=$PWD/xls/dslx/stdlib" >> $GITHUB_ENV
+
       - name: Run pre-commit hooks
+        env:
+          DSLX_STDLIB_PATH: ${{ env.DSLX_STDLIB_PATH }}
         run: |
           pre-commit install
           pre-commit run --all-files

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -1,0 +1,30 @@
+name: run pre-commit tool
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pre-commit hooks
+        run: |
+          pre-commit install
+          pre-commit run --all-files

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -58,4 +58,3 @@ jobs:
         run: |
           pre-commit install
           pre-commit run --all-files
-

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           curl -L "$BINARY_URL" -o dslx_interpreter_main
           chmod +x dslx_interpreter_main
+          export PATH="$PWD:$PATH"
+          echo "PATH=$PWD:$PATH" >> $GITHUB_ENV
 
       - name: Download and extract DSLX standard library
         run: |
@@ -56,3 +58,4 @@ jobs:
         run: |
           pre-commit install
           pre-commit run --all-files
+

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -58,3 +58,7 @@ jobs:
         run: |
           pre-commit install
           pre-commit run --all-files
+
+      - name: Run pytest  # Avoid relying on the pre-commit hook stage.
+        run: |
+          pytest test_prompt.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: no-commit-to-branch
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest test_prompt.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some arguments in favor of LLMs targeting DSLX over the underlying Verilog:
   is fully open source with fully defined semantics and equal representative
   capabilities.  XLS lives "underneath" and completely understands the hardware
   computation descriptions, and is capable of **simulating them at naive speed**.
-  
+
   We can write and slot-in new analysis tools easily, and our understanding of
   the platform is complete -- this is a major challenge for all RTL toolchains
   and Verilog/SystemVerilog semantics in general, often the ones used in practice
@@ -38,7 +38,7 @@ Some arguments in favor of LLMs targeting DSLX over the underlying Verilog:
   * largely pure functions, with limited side effects and immutable values
   * with transparent dataflow semantics
   * and no undefined behavior,
-  
+
   and so can be **verified easily** and then can be **retmined as pipelines**
   (via XLS' scheduler) or lifted into a recurrence in time (via `proc`s, for
   stateful evolution (i.e. **generate a state machine**), similar to how we
@@ -53,7 +53,7 @@ Some arguments in favor of LLMs targeting DSLX over the underlying Verilog:
     Type promotion and matching in expressions is even difficult for expert
     humans to understand and use correctly, in addition to a slew of
     "best practices" required to avoid [traps around 4-value
-    semantics](http://www.sunburst-design.com/papers/CummingsSNUG1999Boston_FullParallelCase_rev1_1.pdf). 
+    semantics](http://www.sunburst-design.com/papers/CummingsSNUG1999Boston_FullParallelCase_rev1_1.pdf).
 * **Straightforwardly composable primitives (i.e. libraries work):**
   the DSL has a standard library of functions that can be composed without fear
   of correctness errors due to the latency-insensitive nature of the design

--- a/prompt.md
+++ b/prompt.md
@@ -132,6 +132,18 @@ fn show_bitwise_concat() {
 
 Note that DSLX code will typically prefer to use the `++` operator instead of the C-style pattern of `x << Y_BITS | y` because it is more correct by construction.
 
+**Shift Amounts Must Be Unsigned** The language does not permit signed shift amounts because it's unclear what a possibly-negative shift would mean in hardware, all shift amounts must be unsigned:
+
+```dslx
+#[test]
+fn show_shifts() {
+    let x = u8:0xab;
+    let y = u32:4;  // Note: unsigned value.
+    assert_eq(x >> y, u8:0xa);
+    assert_eq(x << y, u8:0xb0);
+}
+```
+
 **Enums Require Underlying Width** Unlike in Rust in DSLX we have to note what the integer type underlying an enum is, and enums cannot be sum types as in Rust; in DSLX:
 
 ```dslx
@@ -460,6 +472,21 @@ fn show_numeric_limits() {
     assert_eq(s4::MAX, s4:0x7);
     assert_eq(s4::ZERO, s4:0);
     assert_eq(s4::MIN, s4:-8);
+
+}
+```
+
+Note: there is currently a DSLX grammar restriction where we cannot write `uN[N]::MAX` directly, so we need to write a type alias like so:
+
+```dslx
+const N = u32:4;
+
+#[test]
+fn show_numeric_limits_uN_N() {
+    // does not work: uN[N]::MAX
+    // does work:
+    type MyUN = uN[N];
+    assert_eq(MyUN::MAX, u4:0xf)
 }
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mypy==1.14.1
 pytest==8.3.4
 openai==1.59.8
 termcolor==2.5.0
+pre-commit==4.1

--- a/samples/fixed_arbiter.md
+++ b/samples/fixed_arbiter.md
@@ -22,7 +22,7 @@ fn fixed_arbiter<N: u32>(requests: bits[N], state: ArbiterState<N>) -> (bits[N],
 #[test]
 fn test_fixed_arbiter() {
   let state = ArbiterState<u32:4>{};
-  
+
   // Test case 1: requestors 1 and 3 are requesting
   let requests = bits[4]:0b1010;
   let (grant, state) = fixed_arbiter(requests, state);

--- a/samples/saturating_addsub.md
+++ b/samples/saturating_addsub.md
@@ -1,0 +1,85 @@
+# Saturating Add/Sub
+
+## Prompt
+
+Write a function that performs saturating add/subtract of N-bit values and
+returns a boolean indicating if saturation occurred.
+
+Please emit the `Mode` enum provided into the output answer.
+
+## Signature
+
+```dslx-snippet
+enum Mode : u1 {
+    ADD = 0,
+    SUB = 1,
+}
+fn sat_addsub<N: u32>(x: uN[N], y: uN[N]) -> (bool, uN[N])
+```
+
+## Tests
+
+```dslx-snippet
+#[test]
+fn test_sat_addsub_add_no_saturate() {
+    // 10 + 5 = 15 fits in u8 with no saturation.
+    let (did_sat, result) = sat_addsub<u32:8>(Mode::ADD, u8:10, u8:5);
+    assert_eq(did_sat, false);
+    assert_eq(result, u8:15);
+}
+
+#[test]
+fn test_sat_addsub_add_saturates() {
+    // 15 + 3 = 18 in decimal but max u4 = 15 (0xF).
+    let (did_sat, result) = sat_addsub<u32:4>(Mode::ADD, u4:15, u4:3);
+    assert_eq(did_sat, true);
+    assert_eq(result, u4:15);  // saturated
+}
+
+#[test]
+fn test_sat_addsub_sub_no_saturate() {
+    // 10 - 3 = 7 fits in u8 with no saturation.
+    let (did_sat, result) = sat_addsub<u32:8>(Mode::SUB, u8:10, u8:3);
+    assert_eq(did_sat, false);
+    assert_eq(result, u8:7);
+}
+
+#[test]
+fn test_sat_addsub_sub_saturates() {
+    // 2 - 5 = -3 is below 0, so saturate to 0 in u4.
+    let (did_sat, result) = sat_addsub<u32:4>(Mode::SUB, u4:2, u4:5);
+    assert_eq(did_sat, true);
+    assert_eq(result, u4:0);  // saturated
+}
+
+// Quickcheck property: for ADD we never exceed the max; for SUB we never go below 0.
+#[quickcheck]
+fn prop_sat_addsub_does_not_go_out_of_range(mode: Mode, x: u8, y: u8) -> bool {
+    let (did_sat, result) = sat_addsub(mode, x, y);
+    match mode {
+        Mode::ADD => {
+            // The result must be <= 0xff for u8. (Which DSLX ensures by construction.)
+            // We also can check that "did_sat" is correct if (x + y) > 255.
+            let wide_sum = (x as u16) + (y as u16);
+            let expect_saturate = wide_sum > u16:0xff;
+            let expected_result = if expect_saturate {
+                u8::MAX
+            } else {
+                (wide_sum as u8)
+            };
+            (result == expected_result) && (did_sat == expect_saturate)
+        },
+        _ => {
+            // The result must be >= 0 for u8, i.e. saturate to 0 if underflow.
+            let wide_sub = (x as s16) - (y as s16);
+            let expect_saturate = wide_sub < s16:0;
+            let expected_result = if expect_saturate {
+                u8:0
+            } else {
+                (wide_sub as u8)
+            };
+            (result == expected_result) && (did_sat == expect_saturate)
+        },
+    }
+}
+```

--- a/test_prompt.py
+++ b/test_prompt.py
@@ -11,6 +11,8 @@ import tiktoken
 
 MD_FILE = 'prompt.md'
 
+assert 'DSLX_STDLIB_PATH' in os.environ, 'Please add DSLX_STDLIB_PATH to your environment variables; e.g. `export DSLX_STDLIB_PATH=$HOME/opt/xlsynth/latest/xls/dslx/stdlib/`'
+
 # Regular expression to find code fences labeled 'dslx'
 CODE_FENCE_RE = re.compile(
     r'^```dslx\s*\n(.*?)^```',
@@ -30,14 +32,13 @@ code_samples = extract_dslx_code_samples(MD_FILE)
 @pytest.mark.parametrize('code_sample', code_samples)
 def test_dslx_code_sample(code_sample):
     """Test each DSLX code sample by running it through the interpreter."""
-    with tempfile.NamedTemporaryFile('w', suffix='.dslx', delete=False) as tmp:
+    with tempfile.NamedTemporaryFile('w', suffix='.x', delete=False) as tmp:
         tmp.write(code_sample)
         tmp_filename = tmp.name
 
     cmd = ['dslx_interpreter_main', '--compare=jit', tmp_filename]
-    if 'DSLX_STDLIB_PATH' in os.environ:
-        cmd.append('--dslx_stdlib_path')
-        cmd.append(os.environ['DSLX_STDLIB_PATH'])
+    cmd.append('--dslx_stdlib_path')
+    cmd.append(os.environ['DSLX_STDLIB_PATH'])
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True)


### PR DESCRIPTION
Also:
- makes the eval script print out diffs between attempts
- puts model choices in the help text
- adds notes on unsigned shift amounts and local type aliases to the prompt
- early error if the DSLX stdlib path is not set