### PR TITLE
Tweak the way paths work and add a find_set_bit sample.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To run eval on a specific sample:
 
 ```sh
 export OPENAI_API_KEY=""  # replace with your key
-export DSLX_STDLIB_PATH=""  # replace with DSLX stdlib path
+export XLSYNTH_TOOLS=""  # replace with xlsynth tools dir via github.com/xlsynth/xlsynth/releases
 python eval.py --model gpt-3.5-turbo --sample saturating_addsub --max-retries 5
 ```
 
@@ -100,7 +100,7 @@ we use.
 To test the samples in the prompt Markdown:
 
 ```
-$ DSLX_STDLIB_PATH=$HOME/opt/xlsynth/latest/xls/dslx/stdlib/ pytest test_prompt.py
+DSLX_STDLIB_PATH=$HOME/opt/xlsynth/latest/xls/dslx/stdlib/ pytest test_prompt.py
 ```
 
 ## Ideas not yet added

--- a/prompt.md
+++ b/prompt.md
@@ -539,6 +539,29 @@ fn show_match() {
 }
 ```
 
+**`fail!` built-in** Similar to `todo!()` or `unimplemented!()` or `panic!()` in Rust DSLX has the `fail!(label_string, default_value)` builtin. If failures are "disabled" (i.e. the code is turned to Verilog without assertions enabled) then the `fail!` builtin call expression yields the `default_value`, so that the semantics are always well defined:
+
+```dslx
+fn my_function_that_should_never_get_42(x: u32) -> u32 {
+    match x {
+        u32:42 => fail!("failed_precondition_got_42", u32:0),
+        _ => x,
+    }
+}
+
+#[test]
+fn test_my_function_that_should_never_get_42() {
+    assert_eq(my_function_that_should_never_get_42(u32:1), u32:1);
+    // In the DSLX interpreter this will fail uncommented with:
+    // `FailureError: The program being interpreted failed! u32:0`
+    // But if we converted this to Verilog with assertions disabled it would be well defined to
+    // produce u32:0 in that case.
+    // assert_eq(my_function_that_should_never_get_42(u32:42), u32:0);
+}
+```
+
+Note that this `default_value` also allows the typechecker to see that the types produced by the different match arms are all compatible.
+
 **Quickcheck Tests** Since comprehensive testing is very important for hardware artifacts, DSLX has first class support for quickcheck tests. The quickcheck function can take arbitrary number and type of parameters and it simply has to return a boolean indicating that the test case passed:
 
 ```dslx

--- a/samples/first_set_bit.md
+++ b/samples/first_set_bit.md
@@ -1,0 +1,58 @@
+# Find First Set Bit
+
+## Prompt
+
+Write a routine that finds the first set bit in a bit vector -- it supports giving a relative
+bit index from either the most significant bit side -- in which case the most significant bit is
+numbered 0 -- or from the last significant bit side -- in which case the least significant bit
+is numbered 0.
+
+The return value indicates `(any_bit_set, which_bit_set)` -- when no bit is set the second value
+can be arbitrarily chosen, i.e. it should not be looked at by the caller by contract.
+
+The prologue will be automatically included, just implement the signature in the output answer.
+
+## Prologue
+
+```dslx
+enum Direction : u1 {
+    MSB_IS_0 = 0,
+    LSB_IS_0 = 1,
+}
+```
+
+## Signature
+
+```dslx-snippet
+fn find_first_set_bit<N: u32, N_LOG2: u32 = {std::clog2(N + u32:1)}>(x: uN[N], direction: Direction) -> (bool, uN[N_LOG2])
+```
+
+## Tests
+
+```dslx-snippet
+#[test]
+fn test_simple_lsb_set() {
+    let x = u8:1;
+    assert_eq(find_first_set_bit(x, Direction::LSB_IS_0), (true, u4:0));
+    assert_eq(find_first_set_bit(x, Direction::MSB_IS_0), (true, u4:7));
+}
+
+#[test]
+fn test_simple_msb_set() {
+    let x = u8:0x80;
+    assert_eq(find_first_set_bit(x, Direction::LSB_IS_0), (true, u4:7));
+    assert_eq(find_first_set_bit(x, Direction::MSB_IS_0), (true, u4:0));
+}
+
+#[quickcheck(exhaustive)]
+fn quickcheck_set_one_index_lsb(i: u3) -> bool {
+    let x = bit_slice_update(u8:0, i, true);
+    find_first_set_bit(x, Direction::LSB_IS_0) == (true, i as u4)
+}
+
+#[quickcheck(exhaustive)]
+fn quickcheck_set_one_index_msb(i: u3) -> bool {
+    let x = bit_slice_update(u8:0, u32:8 - i as u32 - u32:1, true);
+    find_first_set_bit(x, Direction::MSB_IS_0) == (true, i as u4)
+}
+```

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,7 @@
+import os
+
+XLSYNTH_TOOLS_DIR = os.environ['XLSYNTH_TOOLS']
+DSLX_INTERPRETER_MAIN = os.path.join(XLSYNTH_TOOLS_DIR, 'dslx_interpreter_main')
+TYPECHECK_MAIN = os.path.join(XLSYNTH_TOOLS_DIR, 'typecheck_main')
+DSLX_STDLIB_PATH = os.path.join(XLSYNTH_TOOLS_DIR, 'xls', 'dslx', 'stdlib')
+assert os.path.isdir(DSLX_STDLIB_PATH), f'DSLX_STDLIB_PATH must be a directory: {DSLX_STDLIB_PATH}'


### PR DESCRIPTION
Things are kind of "standardizing" now in the xlsynth ecosystem on XLSYNTH_TOOLS env var pointing at the release download you want to use, so we adopt that here.