### PR TITLE
Add an ECC sample + update eval harness

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -78,10 +78,10 @@ class CodeGenerator:
         ]
 
     def _get_chat_kwargs(self):
-        if self.model == 'o3-mini':
+        if self.model == 'o3-mini' or self.model == 'o4-mini':
             assert self.reasoning_effort is not None
             return {
-                'model': 'o3-mini',
+                'model': self.model,
                 'reasoning_effort': self.reasoning_effort,
                 'messages': self.messages,
             }
@@ -198,7 +198,7 @@ def evaluate_sample(sample_path: Path, model: str, *, reasoning_effort: Optional
 
         feedback_from_last_iteration = None
         first_attempt_success = False
-        for attempt in range(1, max_retries + 1):
+        for attempt in range(1, max(1, max_retries) + 1):
             print(f"🤖 Attempt {attempt}:")
             if feedback_from_last_iteration is not None:
                 generated_code = codegen.provide_feedback('```\n' + feedback_from_last_iteration + '\n```\n')
@@ -248,7 +248,20 @@ def get_sample_choices() -> list[str]:
 
 def main() -> None:
     """Main function to evaluate all samples."""
-    MODEL_CHOICES = ['gpt-3.5-turbo', 'gpt-4o-mini', 'gpt-4o', 'o1-mini', 'o1-preview', 'o1', 'o3-mini']
+    MODEL_CHOICES = [
+        'gpt-3.5-turbo',
+        'gpt-4o-mini',
+        'gpt-4o',
+        'o1-preview',
+        'o1-mini',
+        'o1',
+        'o1-pro',
+        'o3-mini',
+        'o3',
+        'o4-mini',
+        'gpt-4.1',
+        'gpt-4.1-mini',
+    ]
 
     parser = optparse.OptionParser()
     parser.add_option('--model', default=None, choices=MODEL_CHOICES, help='choose a model to query; choices: %s' % '|'.join(MODEL_CHOICES))

--- a/samples/ecc.md
+++ b/samples/ecc.md
@@ -91,4 +91,11 @@ fn quickcheck_triple_bit_error_not_undetected(message: bits[K], pos0: u32, pos1:
         true
     }
 }
+
+// Tests that the code is in systematic form (first K bits of the encoded codeword match the message).
+#[quickcheck]
+fn quickcheck_systematic(message: bits[K]) -> bool {
+    let codeword = ecc_encoder(message);
+    message == codeword[0 +: uN[K]]
+}
 ```

--- a/samples/ecc.md
+++ b/samples/ecc.md
@@ -2,7 +2,7 @@
 
 ## Prompt
 
-Write an error-correcting code that implements a single-error-correcting, double-error-detecting (SECDED) behavior for a K=64-bit message.
+Write an error-correcting code that implements a single-error-correcting, double-error-detecting (SECDED) behavior for a K-bit message.
 You are free to decide the code construction, including the number of parity bits (R), with the requirement that the code is in systematic form.
 A codeword is N = K + R bits long and is formed by concatenating the message with the generated parity bits.
 
@@ -12,13 +12,16 @@ The SECDED code must correct all single-bit flips, detect (but not correct) all 
 Your task is to design the code construction and implement the encoder and decoder pair for that construction.
 You do not control the channel between the encoder and decoder, i.e., you will never be told whether any bits are flipped, nor their potential locations.
 
+You only need to implement for the following code parameters:
+* K = 64
+* R = 8
+* N = 72
+
 The prologue will be automatically included, just implement the signature in the output answer.
 
 ## Prologue
 
 ```dslx
-import std;
-
 // Instance parameters for the (72,64) SECDED code.
 const K = u32:64;
 const R = u32:8;
@@ -27,7 +30,7 @@ const N = K + R;
 
 ## Signature
 
-```dslx
+```dslx-snippet
 // Encodes a K-bit message into an N-bit codeword in systematic form.
 fn ecc_encoder(message: bits[K]) -> bits[N]
 

--- a/samples/ecc.md
+++ b/samples/ecc.md
@@ -7,7 +7,7 @@ You are free to decide the code construction, including the number of parity bit
 A codeword is N = K + R bits long and is formed by concatenating the message with the generated parity bits.
 
 Codewords may be corrupted by bit flips outside of your control.
-The SECDED code must correct all single-bit flips, detect (but not correct) all double-bit flips, and either detect or attempt to correct all triple-bit flips.
+The SECDED code must correct all single-bit flips, detect (but not correct) all double-bit flips, and either detect or attempt to correct all triple-bit flips (they cannot go undetected).
 
 Your task is to design the code construction and implement the encoder and decoder pair for that construction.
 You do not control the channel between the encoder and decoder, i.e., you will never be told whether any bits are flipped, nor their potential locations.
@@ -17,21 +17,22 @@ The prologue will be automatically included, just implement the signature in the
 ## Prologue
 
 ```dslx
+import std;
+
+// Instance parameters for the (72,64) SECDED code.
+const K = u32:64;
+const R = u32:8;
+const N = K + R;
 ```
 
 ## Signature
 
-```dslx-snippet
-// Encodes a K-bit message into an N-bit codeword.
-fn ecc_encoder<K: u32>(message: bits[K]) -> (bits[N])
+```dslx
+// Encodes a K-bit message into an N-bit codeword in systematic form.
+fn ecc_encoder(message: bits[K]) -> bits[N]
 
-// Decodes an N-bit received codeword into a tuple:
-// * K-bit message
-// * 1-bit corrected error (CE) flag
-// * 1-bit detected-but-uncorrectable error (DUE) flag
-//
-// The CE and DUE flags are mutually exclusive.
-fn ecc_decoder<N: u32>(received_codeword: bits[N]) -> (bits[K], bool, bool)
+// Decodes an N-bit received codeword, corrects single-bit errors, detects double errors.
+fn ecc_decoder(received: bits[N]) -> (bits[K], bool, bool)
 ```
 
 ## Tests
@@ -43,5 +44,48 @@ fn quickcheck_no_errors(message: bits[K]) -> bool {
     let codeword = ecc_encoder(message);
     let (decoded_message, ce, due) = ecc_decoder(codeword);
     !ce && !due && message == decoded_message
+}
+
+// Tests that all single-bit errors are corrected.
+#[quickcheck]
+fn quickcheck_single_bit_error_correction(message: bits[K], pos: u32) -> bool {
+    let codeword = ecc_encoder(message);
+    if pos < N {
+        let received_codeword = bit_slice_update(codeword, pos, (!codeword[pos +: u1]) as u1);
+        let (decoded_message, ce, due) = ecc_decoder(received_codeword);
+        ce && !due && decoded_message == message
+    } else {
+        true
+    }
+}
+
+// Tests that all double-bit errors are detected.
+#[quickcheck]
+fn quickcheck_double_bit_error_detection(message: bits[K], pos0: u32, pos1: u32) -> bool {
+    let codeword = ecc_encoder(message);
+    if pos0 < N && pos1 < N && pos0 < pos1 {
+        let flipped0 = bit_slice_update(codeword, pos0, (!codeword[pos0 +: u1]) as u1);
+        let received_codeword = bit_slice_update(flipped0, pos1, (!flipped0[pos1 +: u1]) as u1);
+        let (_, ce, due) = ecc_decoder(received_codeword);
+        !ce && due
+    } else {
+        true
+    }
+}
+
+// Tests that all triple-bit errors are detected. They may sometimes be corrected or miscorrected, but
+// must not be silently undetected.
+#[quickcheck]
+fn quickcheck_triple_bit_error_not_undetected(message: bits[K], pos0: u32, pos1: u32, pos2: u32) -> bool {
+    let codeword = ecc_encoder(message);
+    if pos0 < N && pos1 < N && pos2 < N && pos0 < pos1 && pos1 < pos2 {
+        let flipped0 = bit_slice_update(codeword, pos0, (!codeword[pos0 +: u1]) as u1);
+        let flipped1 = bit_slice_update(flipped0, pos1, (!flipped0[pos1 +: u1]) as u1);
+        let received_codeword = bit_slice_update(flipped1, pos2, (!flipped1[pos2 +: u1]) as u1);
+        let (_, ce, due) = ecc_decoder(received_codeword);
+        ce || due
+    } else {
+        true
+    }
 }
 ```

--- a/samples/ecc.md
+++ b/samples/ecc.md
@@ -1,0 +1,47 @@
+# Error-Correcting Code
+
+## Prompt
+
+Write an error-correcting code that implements a single-error-correcting, double-error-detecting (SECDED) behavior for a K=64-bit message.
+You are free to decide the code construction, including the number of parity bits (R), with the requirement that the code is in systematic form.
+A codeword is N = K + R bits long and is formed by concatenating the message with the generated parity bits.
+
+Codewords may be corrupted by bit flips outside of your control.
+The SECDED code must correct all single-bit flips, detect (but not correct) all double-bit flips, and either detect or attempt to correct all triple-bit flips.
+
+Your task is to design the code construction and implement the encoder and decoder pair for that construction.
+You do not control the channel between the encoder and decoder, i.e., you will never be told whether any bits are flipped, nor their potential locations.
+
+The prologue will be automatically included, just implement the signature in the output answer.
+
+## Prologue
+
+```dslx
+```
+
+## Signature
+
+```dslx-snippet
+// Encodes a K-bit message into an N-bit codeword.
+fn ecc_encoder<K: u32>(message: bits[K]) -> (bits[N])
+
+// Decodes an N-bit received codeword into a tuple:
+// * K-bit message
+// * 1-bit corrected error (CE) flag
+// * 1-bit detected-but-uncorrectable error (DUE) flag
+//
+// The CE and DUE flags are mutually exclusive.
+fn ecc_decoder<N: u32>(received_codeword: bits[N]) -> (bits[K], bool, bool)
+```
+
+## Tests
+
+```dslx-snippet
+// Tests the encoder and decoder without any injected errors.
+#[quickcheck]
+fn quickcheck_no_errors(message: bits[K]) -> bool {
+    let codeword = ecc_encoder(message);
+    let (decoded_message, ce, due) = ecc_decoder(codeword);
+    !ce && !due && message == decoded_message
+}
+```

--- a/samples/ecc.md
+++ b/samples/ecc.md
@@ -3,8 +3,8 @@
 ## Prompt
 
 Write an error-correcting code that implements a single-error-correcting, double-error-detecting (SECDED) behavior for a K-bit message.
-You are free to decide the code construction, including the number of parity bits (R), with the requirement that the code is in systematic form.
-A codeword is N = K + R bits long and is formed by concatenating the message with the generated parity bits.
+You are free to decide the code construction, as long as the code is in systematic form and codewords are N = K + R bits long, where R is the number of parity bits.
+Systematic form means codewords are encoded by concatenating the message with the generated parity bits.
 
 Codewords may be corrupted by bit flips outside of your control.
 The SECDED code must correct all single-bit flips, detect (but not correct) all double-bit flips, and either detect or attempt to correct all triple-bit flips (they cannot go undetected).


### PR DESCRIPTION
* Add SECDED ECC sample problem
* Generalize `test_prompt.py` to support multiple functions in the signature
* Fix retries bug (retries of 0 should mean exactly 1 attempt)
* Support more OpenAI models