### PR TITLE
Adjust the prompt to reduce commonly occurring errors 

### DIFF
--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Fetch latest XLSynth release
         id: fetch-xlsynth
         run: |
-          API_URL="https://api.github.com/repos/xlsynth/xlsynth/releases/latest"
+          API_URL="https://api.github.com/repos/xlsynth/xlsynth/releases/tags/v0.39.0"
           RESPONSE=$(curl -s "$API_URL")
           DSLX_INTERPRETER_BINARY_URL=$(echo "$RESPONSE" | jq -r '.assets[] | select(.name == "dslx_interpreter_main-ubuntu2004") | .browser_download_url')
           DSLX_TYPECHECK_BINARY_URL=$(echo "$RESPONSE" | jq -r '.assets[] | select(.name == "typecheck_main-ubuntu2004") | .browser_download_url')

--- a/prompt.md
+++ b/prompt.md
@@ -444,7 +444,7 @@ fn show_unsigned_source_extension_is_zero_extension() {
 
 To reiterate: there is never any reason to define a helper function like `zero_extend` or `sign_extend` in DSLX, just use the `as` cast operator -- if the source type is unsigned it will zero extend, and if the source type is signed it will sign extend.
 
-**Keywords** Note that keywords in the language include `bits`, `in`, `out`, `token`, and `chan`, and the `u1` to `u128` and `s1` to `s128`, beyond those you would expect from Rust. Keywords are context-insensitive and so cannot be used as identifiers.
+**Keywords** Note that keywords in the language include `bits`, `in`, `out`, `token`, and `chan`, and the `u1` to `u64` and `s1` to `s64`, beyond those you would expect from Rust. Keywords are context-insensitive and so cannot be used as identifiers.
 
 In particular, you must not name variables `s1`, `s2`, `u8`, etc. Those look like "sum1/sum2" or "u8" to a human, but `s1`..`s128` and `u1`..`u128` are reserved type keywords in DSLX. Using them as identifiers will make the program fail to parse. Prefer names like `sum1`, `sum2`, `carry1`, `tmp`, etc.
 

--- a/prompt.md
+++ b/prompt.md
@@ -507,7 +507,7 @@ Note that sometimes there are limitations on the complexity of expressions you c
 ```dslx
 fn f<N: u32>() {
     const O = N + u32:2;
-    // Note: we bound O so we don't need to write `uN[{N + u32:2}]`.
+    // Note: we bound O as we cannot write `uN[{N + u32:2}]`.
     let x: uN[O] = uN[O]:0;
     trace_fmt!("x: {}", x);
 }


### PR DESCRIPTION
This PR prevents from two commonly occurring errors:
* using `u128` and `s128` which are not available,
* using invalid syntax, e.g.:
```
let b: uN[{A + u32:1}] = a; // Raises: ParseError: Expected start of an expression; got: {
```