### PR TITLE
Support arbitrary OpenAI-compatible model slugs and document OpenRouter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Repository for LLM prompts and Q&A samples for the XLS Domain Specific Language
 * `proc_eval.py`: proc-oriented analogue of `eval.py`, using proc-specific
   prompt material and proc samples under `proc_eval/`.
 * `proc_eval/`: proc-specific prompt collateral, samples, and tests.
+* `docs/openrouter.md`: how to run the harness against arbitrary hosted models
+  through OpenRouter.
 
 To run eval on a specific sample:
 

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -56,6 +56,7 @@ A simple smoke test:
 ```bash
 python eval.py \
   --custom-model-slug openai/gpt-5.4 \
+  --reasoning-effort low \
   --sample majority \
   --max-retries 1
 ```
@@ -80,6 +81,11 @@ python eval.py \
   --max-retries 1
 ```
 
+If you use a separate critic model and that critic model also supports
+reasoning effort, pass `--critic-reasoning-effort` as well. When the critic
+model is the same as the main model, the evaluator reuses the main
+`--reasoning-effort` value by default.
+
 To list available samples:
 
 ```bash
@@ -93,6 +99,7 @@ To evaluate the whole sample suite:
 ```bash
 python eval.py \
   --custom-model-slug google/gemini-2.5-pro \
+  --reasoning-effort high \
   --max-retries 1
 ```
 
@@ -102,6 +109,8 @@ The scorecard prints:
 - first-attempt pass rate
 - all-attempt pass rate
 - token usage totals collected from the OpenAI-compatible response schema
+- the evaluated model variant, including reasoning level when present, e.g.
+  `openai/gpt-5.4@low`
 
 ## Proc samples
 
@@ -110,6 +119,7 @@ The same environment setup works for proc-oriented evaluation:
 ```bash
 python proc_eval.py \
   --custom-model-slug openai/gpt-5.4 \
+  --reasoning-effort low \
   --sample counter \
   --max-retries 1
 ```
@@ -172,6 +182,12 @@ A model can fail for several distinct reasons:
 
 Using OpenRouter does not change the benchmark semantics. The evaluator still
 judges the model by the generated DSLX and the acceptance tests in this repo.
+
+One OpenRouter-specific detail: for some slugs, the repo can detect that
+reasoning parameters are supported but cannot discover the exact allowed enum
+from OpenRouter metadata alone. In those cases the CLI validates against the
+repo's known superset of reasoning levels, and the upstream provider may still
+reject a specific unsupported level for that model.
 
 ## Troubleshooting
 

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -69,6 +69,17 @@ python eval.py \
   --max-retries 1
 ```
 
+Some hosted models expose a reasoning-effort knob. When the selected model
+supports it, `dslx-llm` now requires an explicit `--reasoning-effort` value:
+
+```bash
+python eval.py \
+  --custom-model-slug openai/gpt-5.4 \
+  --reasoning-effort high \
+  --sample majority \
+  --max-retries 1
+```
+
 To list available samples:
 
 ```bash

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -1,0 +1,183 @@
+# Using `dslx-llm` with OpenRouter
+
+This repository can talk to OpenRouter through the existing OpenAI-compatible
+provider path. That makes it easy to try arbitrary hosted models without adding
+new provider-specific code.
+
+## Prerequisites
+
+You need:
+
+- an OpenRouter API key
+- an `xlsynth` tools installation, exposed through `XLSYNTH_TOOLS`
+- the Python dependencies for this repository installed
+
+The eval runner uses the OpenAI-compatible client in `provider_openai.py`, so
+OpenRouter works by setting the base URL and API key through environment
+variables.
+
+## Required environment variables
+
+Set these before running `eval.py` or `proc_eval.py`:
+
+```bash
+export OPENAI_API_KEY="..."
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+export PROVIDER="openai"
+export XLSYNTH_TOOLS="$HOME/opt/xlsynth/latest"
+```
+
+Notes:
+
+- `PROVIDER=openai` is correct here. In this repo, "openai" means "use the
+  OpenAI-compatible chat-completions path", which also covers OpenRouter.
+- `XLSYNTH_TOOLS` should point at an `xlsynth` release directory that contains
+  the DSLX interpreter and stdlib.
+
+## Choosing a model
+
+For built-in local choices, `eval.py` supports `--model`.
+
+For OpenRouter, use `--custom-model-slug` so you can pass any OpenRouter model
+ID directly.
+
+Example model slugs:
+
+- `openai/gpt-5.4`
+- `openai/gpt-oss-120b`
+- `google/gemini-2.5-pro`
+- `anthropic/claude-opus-4.6`
+- `qwen/qwen3.5-122b-a10b`
+
+## Running a single sample
+
+A simple smoke test:
+
+```bash
+python eval.py \
+  --custom-model-slug openai/gpt-5.4 \
+  --sample majority \
+  --max-retries 1
+```
+
+Another example with a hosted open-weight model:
+
+```bash
+python eval.py \
+  --custom-model-slug qwen/qwen3.5-122b-a10b \
+  --sample majority \
+  --max-retries 1
+```
+
+To list available samples:
+
+```bash
+python eval.py --list
+```
+
+## Running the full scorecard
+
+To evaluate the whole sample suite:
+
+```bash
+python eval.py \
+  --custom-model-slug google/gemini-2.5-pro \
+  --max-retries 1
+```
+
+The scorecard prints:
+
+- pass/fail per sample
+- first-attempt pass rate
+- all-attempt pass rate
+- token usage totals collected from the OpenAI-compatible response schema
+
+## Proc samples
+
+The same environment setup works for proc-oriented evaluation:
+
+```bash
+python proc_eval.py \
+  --custom-model-slug openai/gpt-5.4 \
+  --sample counter \
+  --max-retries 1
+```
+
+To list proc samples:
+
+```bash
+python proc_eval.py --list
+```
+
+## Provider pinning for OpenRouter
+
+This repo supports OpenRouter provider routing hints through environment
+variables.
+
+If a model is flaky or slow on the default route, you can pin a provider:
+
+```bash
+export OPENROUTER_PROVIDER_ONLY="alibaba"
+export OPENROUTER_ALLOW_FALLBACKS="false"
+```
+
+That is forwarded as an OpenRouter `provider` override in the request body.
+
+You can also specify multiple providers:
+
+```bash
+export OPENROUTER_PROVIDER_ONLY="parasail,together"
+```
+
+Unset these variables to go back to OpenRouter's default routing behavior.
+
+## Timeouts and retries
+
+Useful knobs:
+
+- `--max-retries`: how many repair attempts the evaluator allows after a
+  failing generation
+- `--timeout`: request timeout in minutes for one model call
+- `--no-critic`: disables the structural requirements critic step
+
+Example:
+
+```bash
+python eval.py \
+  --custom-model-slug anthropic/claude-opus-4.6 \
+  --sample adder_with_carries \
+  --max-retries 1 \
+  --timeout 5
+```
+
+## Notes on benchmark behavior
+
+A model can fail for several distinct reasons:
+
+- invalid DSLX syntax or typing errors
+- correct DSLX that fails the sample tests
+- structurally valid code that fails the optional critic requirements
+- poor instruction-following, such as re-emitting prompt prologue definitions
+
+Using OpenRouter does not change the benchmark semantics. The evaluator still
+judges the model by the generated DSLX and the acceptance tests in this repo.
+
+## Troubleshooting
+
+If requests fail immediately:
+
+- verify `OPENAI_API_KEY` and `OPENAI_BASE_URL`
+- verify `PROVIDER=openai`
+- check that the model slug exists on OpenRouter
+
+If requests hang or are unreliable:
+
+- add `--timeout 5` or another explicit timeout
+- try provider pinning with `OPENROUTER_PROVIDER_ONLY`
+- reduce concurrency if you are running many single-sample evals in parallel
+
+If DSLX execution fails:
+
+- verify `XLSYNTH_TOOLS`
+- confirm the interpreter exists under that directory
+- ensure the stdlib path under that installation is intact

--- a/eval.py
+++ b/eval.py
@@ -15,8 +15,11 @@ from eval_shared import (
     build_full_code,
     collect_dslx_run_flags,
     evaluate_sample_with_runner,
+    format_model_variant,
     get_sample_choices,
     load_system_prompt,
+    REASONING_EFFORT_CHOICES,
+    resolve_reasoning_efforts,
     resolve_sample_files,
 )
 import providers
@@ -129,10 +132,23 @@ def main() -> None:
     parser.add_option('--external-sample', default=None, type=str, help="Path to the external sample that will be evaluated")
     parser.add_option('--external-prompt', default=None, type=str, help="Path to the prompt to use instead of prompt.md")
     parser.add_option('--max-retries', default=3, type=int)
-    parser.add_option('--reasoning-effort', default='high', choices=['low', 'medium', 'high'], help='choose a reasoning effort; choices: %s' % '|'.join(['low', 'medium', 'high']))
+    parser.add_option(
+        '--reasoning-effort',
+        default=None,
+        choices=REASONING_EFFORT_CHOICES,
+        help='reasoning effort for reasoning-capable models; choices: %s'
+             % '|'.join(REASONING_EFFORT_CHOICES),
+    )
     parser.add_option('--no-critic', action='store_true', default=False, help='disable the requirements critic step')
     parser.add_option('--critic-model', default=None, choices=provider.MODEL_CHOICES, help='model to use for requirements critic step (defaults to --model)')
-    parser.add_option('--critic-reasoning-effort', default=None, choices=['low', 'medium', 'high'], help='reasoning effort for critic model (defaults to --reasoning-effort)')
+    parser.add_option(
+        '--critic-reasoning-effort',
+        default=None,
+        choices=REASONING_EFFORT_CHOICES,
+        help='reasoning effort for reasoning-capable critic models '
+             '(defaults to --reasoning-effort when the critic model matches); '
+             'choices: %s' % '|'.join(REASONING_EFFORT_CHOICES),
+    )
     parser.add_option('--test-file', type='string', default=None, help='File with additional tests')
     parser.add_option('--save-to', type='string', default=None, help="Path where generated component should be saved")
     parser.add_option('--reduce-test-errors', type=int, default=None, help='How many (at most) test failures should be provided as a feedback? If None, the whole STDERR is used')
@@ -176,15 +192,25 @@ def main() -> None:
     results: Dict[Path, EvaluateSampleResult] = {}
 
     critic_model = opts.critic_model or model
-    critic_reasoning_effort = opts.critic_reasoning_effort or opts.reasoning_effort
+    reasoning_effort, critic_reasoning_effort = resolve_reasoning_efforts(
+        parser,
+        provider,
+        model=model,
+        reasoning_effort=opts.reasoning_effort,
+        run_critic_step=not opts.no_critic,
+        critic_model=critic_model,
+        critic_reasoning_effort=opts.critic_reasoning_effort,
+    )
+    model_variant = format_model_variant(model, reasoning_effort)
+    critic_variant = format_model_variant(critic_model, critic_reasoning_effort)
 
     for sample_file in sample_files:
-        print(f"Evaluating {sample_file}...")
+        print(f"Evaluating {sample_file} with {model_variant}...")
         result = evaluate_sample(
             sample_file,
             provider,
             model,
-            reasoning_effort=opts.reasoning_effort,
+            reasoning_effort=reasoning_effort,
             max_retries=opts.max_retries,
             run_critic_step=not opts.no_critic,
             critic_model=critic_model,
@@ -201,6 +227,9 @@ def main() -> None:
     first_attempt_success_count = sum(1 for r in results.values() if r.first_attempt_success)
 
     print("\n=== SCORECARD ===")
+    print(f"Model: {model_variant}")
+    if not opts.no_critic:
+        print(f"Critic: {critic_variant}")
     for sample, result in results.items():
         if result.success:
             status = "PASS"

--- a/eval.py
+++ b/eval.py
@@ -118,6 +118,12 @@ def main() -> None:
     parser = optparse.OptionParser()
     parser.add_option('--list', action='store_true', default=False, help='list available samples and exit')
     parser.add_option('--model', default=None, choices=provider.MODEL_CHOICES, help='choose a model to query; choices: %s' % '|'.join(provider.MODEL_CHOICES))
+    parser.add_option(
+        '--custom-model-slug',
+        default=None,
+        type='string',
+        help='use an arbitrary provider model slug instead of the built-in --model choices',
+    )
     parser.add_option('--sample', default=None, choices=get_sample_choices(SAMPLES_DIR), help='evaluate a single sample by name')
     parser.add_option('--only', default=None, help='comma-separated list of samples to evaluate (e.g. foo,bar,baz)')
     parser.add_option('--external-sample', default=None, type=str, help="Path to the external sample that will be evaluated")
@@ -143,8 +149,13 @@ def main() -> None:
             print(name)
         return
 
-    if opts.model is None:
-        parser.error('--model is required')
+    if opts.model is not None and opts.custom_model_slug is not None:
+        parser.error('cannot specify both --model and --custom-model-slug')
+
+    if opts.model is None and opts.custom_model_slug is None:
+        parser.error('either --model or --custom-model-slug is required')
+
+    model = opts.custom_model_slug or opts.model
 
     if opts.external_prompt:
         global PROMPT_FILE
@@ -164,7 +175,7 @@ def main() -> None:
 
     results: Dict[Path, EvaluateSampleResult] = {}
 
-    critic_model = opts.critic_model or opts.model
+    critic_model = opts.critic_model or model
     critic_reasoning_effort = opts.critic_reasoning_effort or opts.reasoning_effort
 
     for sample_file in sample_files:
@@ -172,7 +183,7 @@ def main() -> None:
         result = evaluate_sample(
             sample_file,
             provider,
-            opts.model,
+            model,
             reasoning_effort=opts.reasoning_effort,
             max_retries=opts.max_retries,
             run_critic_step=not opts.no_critic,

--- a/eval_shared.py
+++ b/eval_shared.py
@@ -167,11 +167,15 @@ def evaluate_sample_with_runner(
 ) -> EvaluateSampleResult:
     _, sample_filename = os.path.split(sample_path)
     sample_filename, _ = os.path.splitext(sample_filename)
+    model_slug_for_path = re.sub(r'[^A-Za-z0-9_.-]+', '_', model)
 
     sample = parse_sample(sample_path)
     codegen = provider.CodeGenerator(model, reasoning_effort, system_prompt, timeout)
 
-    with CompatTemporaryDirectory(suffix=f'-{model}-{sample_filename}', delete=False) as tmpdir:
+    with CompatTemporaryDirectory(
+        suffix=f'-{model_slug_for_path}-{sample_filename}',
+        delete=False,
+    ) as tmpdir:
         print('tmpdir:', tmpdir)
 
         all_generated = []

--- a/eval_shared.py
+++ b/eval_shared.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import difflib
+import optparse
 import os
 import re
 from pathlib import Path
@@ -15,6 +16,7 @@ from tempcompat import TemporaryDirectory as CompatTemporaryDirectory
 import critic
 from dslx_run_flags import extract_dslx_run_flags
 from dslx_text import strip_fences
+from openai_compat import REASONING_EFFORT_CHOICES
 import providers
 
 
@@ -149,6 +151,16 @@ class EvaluateSampleResult:
 RunCandidate = Callable[[str, Sample, str, str], RunResult]
 
 
+def format_model_variant(model: str, reasoning_effort: Optional[str]) -> str:
+    if reasoning_effort is None:
+        return model
+    return f'{model}@{reasoning_effort}'
+
+
+def sanitize_model_variant_for_path(model: str, reasoning_effort: Optional[str]) -> str:
+    return re.sub(r'[^A-Za-z0-9_.@-]+', '_', format_model_variant(model, reasoning_effort))
+
+
 def evaluate_sample_with_runner(
     sample_path: Path,
     provider: providers.ProviderModule,
@@ -167,7 +179,7 @@ def evaluate_sample_with_runner(
 ) -> EvaluateSampleResult:
     _, sample_filename = os.path.split(sample_path)
     sample_filename, _ = os.path.splitext(sample_filename)
-    model_slug_for_path = re.sub(r'[^A-Za-z0-9_.-]+', '_', model)
+    model_slug_for_path = sanitize_model_variant_for_path(model, reasoning_effort)
 
     sample = parse_sample(sample_path)
     codegen = provider.CodeGenerator(model, reasoning_effort, system_prompt, timeout)
@@ -323,3 +335,61 @@ def resolve_sample_files(
             sample_files.append(Path(external_sample))
 
     return sample_files
+
+
+def resolve_reasoning_efforts(
+    parser: optparse.OptionParser,
+    provider: providers.ProviderModule,
+    *,
+    model: str,
+    reasoning_effort: Optional[str],
+    run_critic_step: bool,
+    critic_model: str,
+    critic_reasoning_effort: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    reasoning_choices = provider.get_reasoning_effort_choices(model)
+    if reasoning_choices is None:
+        if reasoning_effort is not None:
+            parser.error(
+                f'--reasoning-effort cannot be used with non-reasoning model {model!r}'
+            )
+    else:
+        if reasoning_effort is None:
+            parser.error(
+                f'--reasoning-effort is required for reasoning-capable model {model!r}; '
+                f'allowed values: {", ".join(reasoning_choices)}'
+            )
+        if reasoning_effort not in reasoning_choices:
+            parser.error(
+                f'--reasoning-effort={reasoning_effort!r} is not supported by model '
+                f'{model!r}; allowed values: {", ".join(reasoning_choices)}'
+            )
+
+    if not run_critic_step:
+        return reasoning_effort, None
+
+    if critic_reasoning_effort is None and critic_model == model:
+        critic_reasoning_effort = reasoning_effort
+
+    critic_reasoning_choices = provider.get_reasoning_effort_choices(critic_model)
+    if critic_reasoning_choices is None:
+        if critic_reasoning_effort is not None:
+            parser.error(
+                '--critic-reasoning-effort cannot be used with non-reasoning '
+                f'critic model {critic_model!r}'
+            )
+    else:
+        if critic_reasoning_effort is None:
+            parser.error(
+                f'--critic-reasoning-effort is required for reasoning-capable '
+                f'critic model {critic_model!r}; allowed values: '
+                f'{", ".join(critic_reasoning_choices)}'
+            )
+        if critic_reasoning_effort not in critic_reasoning_choices:
+            parser.error(
+                f'--critic-reasoning-effort={critic_reasoning_effort!r} is not '
+                f'supported by critic model {critic_model!r}; allowed values: '
+                f'{", ".join(critic_reasoning_choices)}'
+            )
+
+    return reasoning_effort, critic_reasoning_effort

--- a/openai_compat.py
+++ b/openai_compat.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility helpers for OpenAI-style text generation APIs.
+
+This module exists to isolate API-shape differences between the legacy Chat
+Completions interface and newer OpenAI-compatible Responses-style interfaces.
+The goal is to keep provider code small and explicit when we need to support
+multiple request/response schemas for the same eval harness.
+
+The intended mental model is:
+
+- Normalize transport and schema differences here.
+- Keep model-behavior policy out of this module.
+- Do not use this layer to "fix" model output or mask instruction-following
+  failures; those should remain visible in eval results.
+
+In practice that means this module is the right place for tasks such as:
+
+- deciding whether a model supports a reasoning-effort parameter,
+- building a Responses API request payload from harness inputs,
+- extracting plain text from different response object layouts,
+- translating usage accounting fields into one common token-total tuple.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from typing import Any, Optional
+
+
+REASONING_EFFORT_CHOICES = ['none', 'low', 'medium', 'high', 'xhigh']
+_REASONING_MODEL_RE = re.compile(r'^(gpt-5(?:$|[-.])|o[1-9](?:$|[-.]))')
+
+
+@dataclasses.dataclass(frozen=True)
+class UsageTotals:
+    """Normalized token accounting for one model response."""
+
+    input: int
+    cached: int
+    output: int
+    total: int
+
+
+def _get_field(value: Any, name: str, default: Any = None) -> Any:
+    """Reads a field from either a dict-backed or attribute-backed object.
+
+    OpenAI-compatible SDKs and transport wrappers are not consistent about
+    whether response objects are plain dictionaries or typed objects. This
+    helper lets the rest of the module read fields without caring which form
+    was returned.
+    """
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def supports_reasoning_effort(model: str) -> bool:
+    """Returns whether the model name appears to support reasoning effort.
+
+    This is a conservative name-based check used to decide whether it is valid
+    to attach a reasoning-effort setting to a request. It is intentionally a
+    lightweight heuristic rather than a capability probe.
+    """
+    return bool(_REASONING_MODEL_RE.match(model.lower()))
+
+
+def resolve_reasoning_effort(model: str, reasoning_effort: Optional[str]) -> Optional[str]:
+    """Normalizes the requested reasoning-effort setting for one model.
+
+    `none` is treated as an explicit request to omit the field entirely. When
+    the caller does not specify a value, reasoning-capable models default to
+    `high` so the harness preserves its current behavior.
+    """
+    if reasoning_effort == 'none':
+        return None
+    if reasoning_effort is not None:
+        return reasoning_effort
+    if supports_reasoning_effort(model):
+        return 'high'
+    return None
+
+
+def build_responses_request(
+    *,
+    model: str,
+    instructions: Optional[str],
+    messages: list[dict[str, str]],
+    reasoning_effort: Optional[str],
+) -> dict[str, Any]:
+    """Builds a Responses API request payload from harness conversation state.
+
+    The harness represents conversations as a list of role/content messages.
+    This helper converts that state into the request shape expected by the
+    Responses API and attaches optional instructions and reasoning config when
+    appropriate.
+    """
+    kwargs: dict[str, Any] = {
+        'model': model,
+        'input': messages,
+        'store': False,
+    }
+    if instructions is not None:
+        kwargs['instructions'] = instructions
+    effective_reasoning_effort = resolve_reasoning_effort(model, reasoning_effort)
+    if effective_reasoning_effort is not None:
+        kwargs['reasoning'] = {'effort': effective_reasoning_effort}
+    return kwargs
+
+
+def create_response(client: Any, **kwargs: Any) -> Any:
+    """Invokes `client.responses.create` with a clearer failure mode.
+
+    Some environments still have an older `openai` package installed that only
+    supports Chat Completions. Raising here makes the dependency problem
+    obvious instead of failing later with a less specific attribute error.
+    """
+    responses_api = getattr(client, 'responses', None)
+    if responses_api is None:
+        raise RuntimeError(
+            'The installed "openai" Python package does not support the Responses API. '
+            'Upgrade dependencies (for example, `pip install -r requirements.txt`) and retry.'
+        )
+    return responses_api.create(**kwargs)
+
+
+def extract_output_text(response: Any) -> str:
+    """Extracts assistant text from a Responses API result object.
+
+    The SDK may expose a convenience `output_text` field, but some compatible
+    implementations only populate the structured `output[].content[]` form.
+    This helper accepts either layout and returns one stripped text string.
+    """
+    output_text = getattr(response, 'output_text', None)
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text.strip()
+
+    chunks: list[str] = []
+    for item in getattr(response, 'output', []) or []:
+        if _get_field(item, 'type') != 'message':
+            continue
+        for content in _get_field(item, 'content', []) or []:
+            text = _get_field(content, 'text')
+            if isinstance(text, str):
+                chunks.append(text)
+
+    if chunks:
+        return ''.join(chunks).strip()
+
+    raise RuntimeError('Responses API returned no text output.')
+
+
+def usage_to_totals(usage: Any) -> UsageTotals | None:
+    """Normalizes usage objects into a `UsageTotals` record.
+
+    OpenAI-compatible APIs do not all report token accounting with the same
+    field names. This helper accepts either Responses-style usage
+    (`input_tokens`, `output_tokens`) or Chat Completions-style usage
+    (`prompt_tokens`, `completion_tokens`) and translates both into a single
+    named record used by the harness.
+    """
+    if usage is None:
+        return None
+
+    input_tokens = _get_field(usage, 'input_tokens')
+    if input_tokens is not None:
+        details = _get_field(usage, 'input_tokens_details')
+        cached_tokens = _get_field(details, 'cached_tokens', 0) or 0
+        output_tokens = _get_field(usage, 'output_tokens', 0) or 0
+        total_tokens = _get_field(usage, 'total_tokens', input_tokens + output_tokens) or 0
+        return UsageTotals(
+            input=input_tokens - cached_tokens,
+            cached=cached_tokens,
+            output=output_tokens,
+            total=total_tokens,
+        )
+
+    prompt_tokens = _get_field(usage, 'prompt_tokens')
+    if prompt_tokens is not None:
+        details = _get_field(usage, 'prompt_tokens_details')
+        cached_tokens = _get_field(details, 'cached_tokens', 0) or 0
+        output_tokens = _get_field(usage, 'completion_tokens', 0) or 0
+        total_tokens = _get_field(usage, 'total_tokens', prompt_tokens + output_tokens) or 0
+        return UsageTotals(
+            input=prompt_tokens - cached_tokens,
+            cached=cached_tokens,
+            output=output_tokens,
+            total=total_tokens,
+        )
+
+    return None

--- a/openai_compat.py
+++ b/openai_compat.py
@@ -15,7 +15,7 @@ The intended mental model is:
 
 In practice that means this module is the right place for tasks such as:
 
-- deciding whether a model supports a reasoning-effort parameter,
+- passing through an already-validated reasoning-effort parameter,
 - building a Responses API request payload from harness inputs,
 - extracting plain text from different response object layouts,
 - translating usage accounting fields into one common token-total tuple.
@@ -24,12 +24,10 @@ In practice that means this module is the right place for tasks such as:
 from __future__ import annotations
 
 import dataclasses
-import re
 from typing import Any, Optional
 
 
-REASONING_EFFORT_CHOICES = ['none', 'low', 'medium', 'high', 'xhigh']
-_REASONING_MODEL_RE = re.compile(r'^(gpt-5(?:$|[-.])|o[1-9](?:$|[-.]))')
+REASONING_EFFORT_CHOICES = ('none', 'minimal', 'low', 'medium', 'high', 'xhigh')
 
 
 @dataclasses.dataclass(frozen=True)
@@ -55,32 +53,6 @@ def _get_field(value: Any, name: str, default: Any = None) -> Any:
     return getattr(value, name, default)
 
 
-def supports_reasoning_effort(model: str) -> bool:
-    """Returns whether the model name appears to support reasoning effort.
-
-    This is a conservative name-based check used to decide whether it is valid
-    to attach a reasoning-effort setting to a request. It is intentionally a
-    lightweight heuristic rather than a capability probe.
-    """
-    return bool(_REASONING_MODEL_RE.match(model.lower()))
-
-
-def resolve_reasoning_effort(model: str, reasoning_effort: Optional[str]) -> Optional[str]:
-    """Normalizes the requested reasoning-effort setting for one model.
-
-    `none` is treated as an explicit request to omit the field entirely. When
-    the caller does not specify a value, reasoning-capable models default to
-    `high` so the harness preserves its current behavior.
-    """
-    if reasoning_effort == 'none':
-        return None
-    if reasoning_effort is not None:
-        return reasoning_effort
-    if supports_reasoning_effort(model):
-        return 'high'
-    return None
-
-
 def build_responses_request(
     *,
     model: str,
@@ -102,9 +74,8 @@ def build_responses_request(
     }
     if instructions is not None:
         kwargs['instructions'] = instructions
-    effective_reasoning_effort = resolve_reasoning_effort(model, reasoning_effort)
-    if effective_reasoning_effort is not None:
-        kwargs['reasoning'] = {'effort': effective_reasoning_effort}
+    if reasoning_effort is not None:
+        kwargs['reasoning'] = {'effort': reasoning_effort}
     return kwargs
 
 

--- a/proc_eval.py
+++ b/proc_eval.py
@@ -14,8 +14,11 @@ from eval_shared import (
     build_full_code,
     collect_dslx_run_flags,
     evaluate_sample_with_runner,
+    format_model_variant,
     get_sample_choices,
     load_system_prompt,
+    REASONING_EFFORT_CHOICES,
+    resolve_reasoning_efforts,
     resolve_sample_files,
 )
 import providers
@@ -146,10 +149,23 @@ def main() -> None:
     parser.add_option('--external-sample', default=None, type=str, help="Path to the external proc sample that will be evaluated")
     parser.add_option('--external-prompt', default=None, type=str, help="Path to the prompt to use instead of proc_eval/prompt.md")
     parser.add_option('--max-retries', default=3, type=int)
-    parser.add_option('--reasoning-effort', default='high', choices=['low', 'medium', 'high'], help='choose a reasoning effort; choices: %s' % '|'.join(['low', 'medium', 'high']))
+    parser.add_option(
+        '--reasoning-effort',
+        default=None,
+        choices=REASONING_EFFORT_CHOICES,
+        help='reasoning effort for reasoning-capable models; choices: %s'
+             % '|'.join(REASONING_EFFORT_CHOICES),
+    )
     parser.add_option('--no-critic', action='store_true', default=False, help='disable the requirements critic step')
     parser.add_option('--critic-model', default=None, choices=provider.MODEL_CHOICES, help='model to use for requirements critic step (defaults to --model)')
-    parser.add_option('--critic-reasoning-effort', default=None, choices=['low', 'medium', 'high'], help='reasoning effort for critic model (defaults to --reasoning-effort)')
+    parser.add_option(
+        '--critic-reasoning-effort',
+        default=None,
+        choices=REASONING_EFFORT_CHOICES,
+        help='reasoning effort for reasoning-capable critic models '
+             '(defaults to --reasoning-effort when the critic model matches); '
+             'choices: %s' % '|'.join(REASONING_EFFORT_CHOICES),
+    )
     parser.add_option('--test-file', type='string', default=None, help='File with additional proc tests')
     parser.add_option('--save-to', type='string', default=None, help="Path where generated proc should be saved")
     parser.add_option('--reduce-test-errors', type=int, default=None, help='How many (at most) test failures should be provided as feedback? If None, the whole STDERR is used')
@@ -196,15 +212,25 @@ def main() -> None:
     results: Dict[Path, EvaluateSampleResult] = {}
 
     critic_model = opts.critic_model or model
-    critic_reasoning_effort = opts.critic_reasoning_effort or opts.reasoning_effort
+    reasoning_effort, critic_reasoning_effort = resolve_reasoning_efforts(
+        parser,
+        provider,
+        model=model,
+        reasoning_effort=opts.reasoning_effort,
+        run_critic_step=not opts.no_critic,
+        critic_model=critic_model,
+        critic_reasoning_effort=opts.critic_reasoning_effort,
+    )
+    model_variant = format_model_variant(model, reasoning_effort)
+    critic_variant = format_model_variant(critic_model, critic_reasoning_effort)
 
     for sample_file in sample_files:
-        print(f"Evaluating {sample_file}...")
+        print(f"Evaluating {sample_file} with {model_variant}...")
         result = evaluate_sample(
             sample_file,
             provider,
             model,
-            reasoning_effort=opts.reasoning_effort,
+            reasoning_effort=reasoning_effort,
             max_retries=opts.max_retries,
             run_critic_step=not opts.no_critic,
             critic_model=critic_model,
@@ -224,6 +250,9 @@ def main() -> None:
     first_attempt_success_count = sum(1 for r in results.values() if r.first_attempt_success)
 
     print("\n=== SCORECARD ===")
+    print(f"Model: {model_variant}")
+    if not opts.no_critic:
+        print(f"Critic: {critic_variant}")
     for sample, result in results.items():
         if result.success:
             status = "PASS"

--- a/proc_eval.py
+++ b/proc_eval.py
@@ -135,6 +135,12 @@ def main() -> None:
     parser = optparse.OptionParser()
     parser.add_option('--list', action='store_true', default=False, help='list available proc samples and exit')
     parser.add_option('--model', default=None, choices=provider.MODEL_CHOICES, help='choose a model to query; choices: %s' % '|'.join(provider.MODEL_CHOICES))
+    parser.add_option(
+        '--custom-model-slug',
+        default=None,
+        type='string',
+        help='use an arbitrary provider model slug instead of the built-in --model choices',
+    )
     parser.add_option('--sample', default=None, choices=get_sample_choices(SAMPLES_DIR), help='evaluate a single proc sample by name')
     parser.add_option('--only', default=None, help='comma-separated list of proc samples to evaluate (e.g. foo,bar,baz)')
     parser.add_option('--external-sample', default=None, type=str, help="Path to the external proc sample that will be evaluated")
@@ -163,8 +169,13 @@ def main() -> None:
             print(name)
         return
 
-    if opts.model is None:
-        parser.error('--model is required')
+    if opts.model is not None and opts.custom_model_slug is not None:
+        parser.error('cannot specify both --model and --custom-model-slug')
+
+    if opts.model is None and opts.custom_model_slug is None:
+        parser.error('either --model or --custom-model-slug is required')
+
+    model = opts.custom_model_slug or opts.model
 
     if opts.external_prompt:
         global PROMPT_FILE
@@ -184,7 +195,7 @@ def main() -> None:
 
     results: Dict[Path, EvaluateSampleResult] = {}
 
-    critic_model = opts.critic_model or opts.model
+    critic_model = opts.critic_model or model
     critic_reasoning_effort = opts.critic_reasoning_effort or opts.reasoning_effort
 
     for sample_file in sample_files:
@@ -192,7 +203,7 @@ def main() -> None:
         result = evaluate_sample(
             sample_file,
             provider,
-            opts.model,
+            model,
             reasoning_effort=opts.reasoning_effort,
             max_retries=opts.max_retries,
             run_critic_step=not opts.no_critic,

--- a/provider_google.py
+++ b/provider_google.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
 import json
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 from google import genai
 from google.genai import types
@@ -11,13 +10,14 @@ import termcolor
 
 from dslx_text import strip_fences
 import critic
+from openai_compat import REASONING_EFFORT_CHOICES
 
 
-NEED_REASONING_EFFORT = set([
+SUPPORTED_REASONING_MODELS = {
     'gemini-3-flash-preview',
     'gemini-3.1-flash-lite-preview',
     'gemini-3.1-pro-preview',
-])
+}
 MODEL_CHOICES = [
     'gemini-3-flash-preview',
     'gemini-3.1-flash-lite-preview',
@@ -44,9 +44,18 @@ def print_usage(usage: Any | None) -> None:
     )
 
 
+def supports_reasoning_effort(model: str) -> bool:
+    return model in SUPPORTED_REASONING_MODELS
+
+
+def get_reasoning_effort_choices(model: str) -> tuple[str, ...] | None:
+    if model in SUPPORTED_REASONING_MODELS:
+        return tuple(level for level in REASONING_EFFORT_CHOICES if level in ('low', 'medium', 'high'))
+    return None
+
+
 def _chat_kwargs(model: str, reasoning_effort: Optional[str], messages):
-    if model in NEED_REASONING_EFFORT:
-        assert reasoning_effort is not None
+    if reasoning_effort is not None:
         return {
             'model': model,
             'contents': [types.Content(
@@ -67,8 +76,6 @@ def _parse_critic_json(text: str) -> dict:
 
 
 class CodeGenerator:
-    # Models that require a reasoning effort config to be set.
-
     def __init__(
         self,
         model: str,

--- a/provider_openai.py
+++ b/provider_openai.py
@@ -2,6 +2,8 @@
 
 import dataclasses
 import json
+import os
+import time
 from typing import Optional, List, Dict, Any
 
 try:
@@ -62,14 +64,46 @@ def print_usage(usage: Any | None) -> None:
 def _chat_kwargs(model: str, reasoning_effort: Optional[str], messages):
     if model in NEED_REASONING_EFFORT:
         assert reasoning_effort is not None
-        return {'model': model, 'reasoning_effort': reasoning_effort, 'messages': messages}
-    return {'model': model, 'messages': messages}
+        kwargs = {'model': model, 'reasoning_effort': reasoning_effort, 'messages': messages}
+    else:
+        kwargs = {'model': model, 'messages': messages}
+    kwargs.update(_request_overrides())
+    return kwargs
+
+
+def _request_overrides() -> dict[str, Any]:
+    provider_only = os.environ.get('OPENROUTER_PROVIDER_ONLY')
+    if not provider_only:
+        return {}
+
+    only = [value.strip() for value in provider_only.split(',') if value.strip()]
+    provider: dict[str, Any] = {'only': only}
+
+    allow_fallbacks = os.environ.get('OPENROUTER_ALLOW_FALLBACKS')
+    if allow_fallbacks is not None:
+        provider['allow_fallbacks'] = allow_fallbacks.lower() in ('1', 'true', 'yes')
+
+    return {'extra_body': {'provider': provider}}
 
 
 def _parse_critic_json(text: str) -> dict:
     # Allow the critic to wrap the JSON in a triple-backtick block.
     raw = strip_fences(text).strip()
     return json.loads(raw)
+
+
+def _create_chat_completion_with_retries(client: Any, **kwargs: Any) -> Any:
+    for attempt in range(1, 4):
+        try:
+            return client.chat.completions.create(**kwargs)
+        except json.JSONDecodeError:
+            if attempt == 3:
+                raise
+            termcolor.cprint(
+                f"Malformed JSON response from OpenAI-compatible backend; retrying ({attempt}/3)...",
+                color="yellow",
+            )
+            time.sleep(attempt)
 
 
 class CodeGenerator:
@@ -106,7 +140,9 @@ class CodeGenerator:
         termcolor.cprint('PROBLEM', color='blue')
         self.messages.append({"role": "user", "content": message})
 
-        response = self.client.chat.completions.create(**self._get_chat_kwargs())
+        response = _create_chat_completion_with_retries(
+            self.client, **self._get_chat_kwargs()
+        )
         print_usage(response.usage)
 
         assistant_response = (response.choices[0].message.content or '').strip()
@@ -117,7 +153,9 @@ class CodeGenerator:
     def provide_feedback(self, error_message: str) -> str:
         self.messages.append({"role": "user", "content": f"Error encountered:\n{error_message}"})
 
-        response = self.client.chat.completions.create(**self._get_chat_kwargs())
+        response = _create_chat_completion_with_retries(
+            self.client, **self._get_chat_kwargs()
+        )
         print_usage(response.usage)
 
         assistant_response = (response.choices[0].message.content or '').strip()
@@ -165,8 +203,9 @@ def run_critic(
 
     last_text = ""
     for _attempt in range(1, 3):
-        response = client.chat.completions.create(
-            **_chat_kwargs(critic_model, critic_reasoning_effort, messages)
+        response = _create_chat_completion_with_retries(
+            client,
+            **_chat_kwargs(critic_model, critic_reasoning_effort, messages),
         )
         last_text = (response.choices[0].message.content or '').strip()
         try:

--- a/provider_openai.py
+++ b/provider_openai.py
@@ -42,12 +42,19 @@ def print_usage(usage: Any | None) -> None:
     if usage is None:
         return
 
-    TOTAL_USAGE["cached"] += usage.prompt_tokens_details.cached_tokens
-    TOTAL_USAGE["input"] += usage.prompt_tokens - usage.prompt_tokens_details.cached_tokens
-    TOTAL_USAGE["output"] += usage.completion_tokens
+    # OpenAI-compatible backends such as vLLM can omit nested usage details, so
+    # read these fields defensively instead of assuming the hosted OpenAI schema.
+    prompt_tokens_details = getattr(usage, 'prompt_tokens_details', None)
+    cached_tokens = getattr(prompt_tokens_details, 'cached_tokens', 0) or 0
+    prompt_tokens = getattr(usage, 'prompt_tokens', 0) or 0
+    completion_tokens = getattr(usage, 'completion_tokens', 0) or 0
+
+    TOTAL_USAGE["cached"] += cached_tokens
+    TOTAL_USAGE["input"] += prompt_tokens - cached_tokens
+    TOTAL_USAGE["output"] += completion_tokens
     termcolor.cprint(
-        f"Used tokens - in {usage.prompt_tokens} (cached {usage.prompt_tokens_details.cached_tokens})"
-        f" - out {usage.completion_tokens} - total {usage.total_tokens}",
+        f"Used tokens - in {prompt_tokens} (cached {cached_tokens})"
+        f" - out {completion_tokens} - total {getattr(usage, 'total_tokens', 0) or 0}",
         color="red",
     )
 
@@ -102,7 +109,7 @@ class CodeGenerator:
         response = self.client.chat.completions.create(**self._get_chat_kwargs())
         print_usage(response.usage)
 
-        assistant_response = response.choices[0].message.content.strip()
+        assistant_response = (response.choices[0].message.content or '').strip()
         self.messages.append({"role": "assistant", "content": assistant_response})
 
         return assistant_response
@@ -113,7 +120,7 @@ class CodeGenerator:
         response = self.client.chat.completions.create(**self._get_chat_kwargs())
         print_usage(response.usage)
 
-        assistant_response = response.choices[0].message.content.strip()
+        assistant_response = (response.choices[0].message.content or '').strip()
         self.messages.append({"role": "assistant", "content": assistant_response})
 
         return assistant_response
@@ -161,7 +168,7 @@ def run_critic(
         response = client.chat.completions.create(
             **_chat_kwargs(critic_model, critic_reasoning_effort, messages)
         )
-        last_text = response.choices[0].message.content.strip()
+        last_text = (response.choices[0].message.content or '').strip()
         try:
             parsed = _parse_critic_json(last_text)
         except Exception as e:

--- a/provider_openai.py
+++ b/provider_openai.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
 import json
 import os
 import time
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
+import urllib.request
 
 try:
     import openai  # type: ignore
@@ -14,9 +14,21 @@ import termcolor
 
 from dslx_text import strip_fences
 import critic
+from openai_compat import REASONING_EFFORT_CHOICES
 
 
-NEED_REASONING_EFFORT = set(['o3-mini', 'o4-mini', 'gpt-5.1', 'gpt-5.2'])
+# Exact per-model reasoning effort choices taken from the official OpenAI model
+# docs. We key these by the canonical first-party model id and also reuse them
+# for equivalent OpenRouter slugs after stripping the leading `openai/`.
+KNOWN_REASONING_LEVEL_CHOICES = {
+    'gpt-5.1': ('none', 'low', 'medium', 'high'),
+    'gpt-5.2': ('none', 'low', 'medium', 'high', 'xhigh'),
+    'gpt-5.4': ('none', 'low', 'medium', 'high', 'xhigh'),
+    'gpt-5.4-mini': ('none', 'low', 'medium', 'high', 'xhigh'),
+    'gpt-5.4-nano': ('none', 'low', 'medium', 'high', 'xhigh'),
+    'gpt-oss-20b': ('low', 'medium', 'high'),
+    'gpt-oss-120b': ('low', 'medium', 'high'),
+}
 MODEL_CHOICES = [
     'gpt-3.5-turbo',
     'gpt-4o-mini',
@@ -38,6 +50,92 @@ TOTAL_USAGE = {
     "cached": 0,
     "output": 0,
 }
+_OPENROUTER_REASONING_SUPPORT: dict[str, bool] | None = None
+
+
+def _canonical_model_name(model: str) -> str:
+    if model.startswith('openai/'):
+        return model[len('openai/'):]
+    return model
+
+
+def _get_known_reasoning_effort_choices(model: str) -> tuple[str, ...] | None:
+    canonical_model = _canonical_model_name(model)
+    for known_model, choices in sorted(
+        KNOWN_REASONING_LEVEL_CHOICES.items(),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    ):
+        if canonical_model == known_model or canonical_model.startswith(known_model + '-'):
+            return choices
+    return None
+
+
+def _is_openrouter_base_url() -> bool:
+    base_url = os.environ.get('OPENAI_BASE_URL', '')
+    return 'openrouter.ai' in base_url.lower()
+
+
+def _get_openrouter_reasoning_support() -> dict[str, bool]:
+    global _OPENROUTER_REASONING_SUPPORT
+    if _OPENROUTER_REASONING_SUPPORT is not None:
+        return _OPENROUTER_REASONING_SUPPORT
+
+    if not _is_openrouter_base_url():
+        _OPENROUTER_REASONING_SUPPORT = {}
+        return _OPENROUTER_REASONING_SUPPORT
+
+    models_url = os.environ['OPENAI_BASE_URL'].rstrip('/') + '/models'
+    headers = {'Accept': 'application/json'}
+    api_key = os.environ.get('OPENAI_API_KEY')
+    if api_key:
+        headers['Authorization'] = f'Bearer {api_key}'
+
+    request = urllib.request.Request(models_url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read().decode('utf-8'))
+    except Exception:
+        _OPENROUTER_REASONING_SUPPORT = {}
+        return _OPENROUTER_REASONING_SUPPORT
+
+    result: dict[str, bool] = {}
+    entries = payload.get('data', []) if isinstance(payload, dict) else []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        model_id = entry.get('id')
+        if not isinstance(model_id, str):
+            continue
+        supported_parameters = entry.get('supported_parameters') or []
+        if not isinstance(supported_parameters, list):
+            continue
+        # OpenRouter exposes whether reasoning parameters are supported, but not
+        # the exact per-model reasoning effort enum.
+        result[model_id] = (
+            'reasoning' in supported_parameters
+            or 'reasoning_effort' in supported_parameters
+        )
+
+    _OPENROUTER_REASONING_SUPPORT = result
+    return _OPENROUTER_REASONING_SUPPORT
+
+
+def get_reasoning_effort_choices(model: str) -> tuple[str, ...] | None:
+    if choices := _get_known_reasoning_effort_choices(model):
+        return choices
+
+    if _get_openrouter_reasoning_support().get(model, False):
+        # OpenRouter tells us whether reasoning parameters are supported, but
+        # not the exact allowed enum, so fall back to the global superset when
+        # we do not have a model-specific table entry.
+        return REASONING_EFFORT_CHOICES
+
+    return None
+
+
+def supports_reasoning_effort(model: str) -> bool:
+    return get_reasoning_effort_choices(model) is not None
 
 
 def print_usage(usage: Any | None) -> None:
@@ -62,11 +160,9 @@ def print_usage(usage: Any | None) -> None:
 
 
 def _chat_kwargs(model: str, reasoning_effort: Optional[str], messages):
-    if model in NEED_REASONING_EFFORT:
-        assert reasoning_effort is not None
-        kwargs = {'model': model, 'reasoning_effort': reasoning_effort, 'messages': messages}
-    else:
-        kwargs = {'model': model, 'messages': messages}
+    kwargs = {'model': model, 'messages': messages}
+    if reasoning_effort is not None:
+        kwargs['reasoning_effort'] = reasoning_effort
     kwargs.update(_request_overrides())
     return kwargs
 
@@ -107,8 +203,6 @@ def _create_chat_completion_with_retries(client: Any, **kwargs: Any) -> Any:
 
 
 class CodeGenerator:
-    # Models that require a reasoning effort config to be set.
-
     def __init__(
         self,
         model: str,

--- a/providers.py
+++ b/providers.py
@@ -15,6 +15,12 @@ class ClassGenerator(Protocol):
 
 class ProviderModule(Protocol):
     @staticmethod
+    def supports_reasoning_effort(model: str) -> bool: ...
+
+    @staticmethod
+    def get_reasoning_effort_choices(model: str) -> tuple[str, ...] | None: ...
+
+    @staticmethod
     def CodeGenerator(
             model: str,
             reasoning_effort: Optional[str],

--- a/samples/count_leading_zeros.md
+++ b/samples/count_leading_zeros.md
@@ -7,6 +7,20 @@ Implement a function that computes the number of leading zeros in an N-bit unsig
 Count the number of consecutive `0`-bits starting from the most-significant bit, until the first
 `1`-bit is encountered. If the input is `0`, the function should return `N`.
 
+## Requirements
+
+The following requirements will be checked by a separate critic model. The critic should treat
+comments as claims, not proof, and decide from the actual DSLX structure.
+
+- id: loop_carried_found_state
+  requirement: The implementation must use a bounded DSLX `for` loop with loop-carried state that tracks both the running zero count and whether the first `1` bit has already been seen, or an equivalent two-state formulation.
+
+- id: not_builtin_clz
+  requirement: The implementation must not solve the problem by calling a built-in such as `clz` or by wrapping such a built-in in a helper. The counting behavior should be expressed directly in the DSLX implementation.
+
+- id: scan_from_msb_toward_lsb
+  requirement: The loop/dataflow should examine bit positions from the most-significant side toward the least-significant side, carrying the "done" condition forward once a `1` is encountered.
+
 ## Signature
 
 ```dslx-snippet

--- a/samples/integer_sqrt.md
+++ b/samples/integer_sqrt.md
@@ -4,6 +4,20 @@
 
 Write a DSLX function that computes the integer square root of a given non-negative integer. Use the **non-restoring algorithm**. The function should be parameterizable for different bit widths. The function should return the floor of the square root of the input value.
 
+## Requirements
+
+The following requirements will be checked by a separate critic model. The critic should treat
+comments as claims, not proof, and decide from the actual DSLX structure.
+
+- id: bounded_iterative_algorithm
+  requirement: The implementation must use a bounded iterative formulation, such as a counted DSLX `for` loop over root-digit or bit-pair steps, rather than a `while` loop, brute-force search over candidates, or a direct closed-form expression.
+
+- id: non_restoring_state_update
+  requirement: The implementation must maintain explicit step-to-step algorithm state consistent with a non-restoring square-root method, such as partial remainder and partial root (or equivalent state variables), and update that state each iteration.
+
+- id: not_builtin_or_linear_search
+  requirement: The implementation must not call a built-in square-root helper, convert through floating-point to compute the answer, or linearly search candidate roots by checking `r * r <= value`.
+
 ## Signature
 
 ```dslx-snippet

--- a/samples/prefix_sum.md
+++ b/samples/prefix_sum.md
@@ -4,6 +4,20 @@
 
 Write a DSLX function that calculates the prefix sum of an array.
 
+## Requirements
+
+The following requirements will be checked by a separate critic model. The critic should treat
+comments as claims, not proof, and decide from the actual DSLX structure.
+
+- id: running_sum_loop_state
+  requirement: The implementation must use loop-carried state that evolves the running prefix sum from one element to the next, rather than recomputing each prefix independently from scratch.
+
+- id: output_array_built_incrementally
+  requirement: The output array must be built incrementally as the loop progresses, for example via tuple accumulator state plus `update(...)` on an array accumulator, or an equivalent staged construction.
+
+- id: not_quadratic_rescan_strategy
+  requirement: The implementation must not use a nested "for each output position, rescan the prefix" strategy or another obviously quadratic recomputation approach when a linear prefix accumulation is possible.
+
 ## Signature
 
 ```dslx-snippet

--- a/test_prompt.py
+++ b/test_prompt.py
@@ -15,6 +15,7 @@ import tools
 from dslx_run_flags import split_dslx_run_flags_from_code
 
 PROMPT_MD_FILE = 'prompt.md'
+SAMPLE_DIRS = ('samples',)
 
 # Samples that intentionally require model-defined nominal types in signatures.
 # These are not compatible with the generic stub typecheck harness.
@@ -117,24 +118,34 @@ def create_sample_with_stub(filename: str, md_content: str) -> CodeSample:
     return CodeSample(name=os.path.splitext(filename)[0], content=f'import std;\n{prologue}\n{stubs}\n{tests}')
 
 
-def create_samples_with_stubs() -> list[CodeSample]:
+def iter_sample_markdown_files(sample_dirs: tuple[str, ...]) -> list[str]:
+    """Returns sample markdown files from the requested directories."""
+    result: list[str] = []
+    for sample_dir in sample_dirs:
+        if not os.path.isdir(sample_dir):
+            continue
+        for filename in sorted(os.listdir(sample_dir)):
+            if filename.endswith('.md'):
+                result.append(os.path.join(sample_dir, filename))
+    return result
+
+
+def create_samples_with_stubs(sample_dirs: tuple[str, ...]) -> list[CodeSample]:
     """Creates samples with stubs for each DSLX code sample."""
     results = []
-    for filename in os.listdir('samples'):
-        if not filename.endswith('.md'):
-            continue
-        sample_name = os.path.splitext(filename)[0]
+    for path in iter_sample_markdown_files(sample_dirs):
+        sample_name = os.path.splitext(os.path.basename(path))[0]
         if sample_name in STUB_TYPECHECK_SKIP:
             continue
-        with open(f'samples/{filename}', 'r') as f:
+        with open(path, 'r') as f:
             md_content = f.read()
-        results.append(create_sample_with_stub(filename, md_content))
+        results.append(create_sample_with_stub(path, md_content))
     return results
 
 
 # Extract code samples from the markdown file
 PROMPT_CODE_SAMPLES = extract_dslx_code_samples(PROMPT_MD_FILE)
-SAMPLES_WITH_STUBS = create_samples_with_stubs()
+SAMPLES_WITH_STUBS = create_samples_with_stubs(SAMPLE_DIRS)
 
 
 def run_on_single_file(binary: str, code_sample: str, more_flags: tuple[str, ...] = ()):
@@ -191,28 +202,28 @@ def test_prompt_size():
 
 # Added test for replacing signature with naive_reference in samples that contain 'fn naive_reference'
 NAIVE_REFERENCE_FILES = [
-    filename for filename in os.listdir("samples")
-    if filename.endswith(".md") and "fn naive_reference" in open(os.path.join("samples", filename)).read()
+    path for path in iter_sample_markdown_files(SAMPLE_DIRS)
+    if "fn naive_reference" in open(path).read()
 ]
 
-@pytest.mark.parametrize("sample_filename", NAIVE_REFERENCE_FILES)
-def test_naive_reference_replacement(sample_filename: str) -> None:
+@pytest.mark.parametrize("sample_path", NAIVE_REFERENCE_FILES, ids=lambda x: x)
+def test_naive_reference_replacement(sample_path: str) -> None:
     # Get the DSLX snippet from the `## Tests` section of the sample markdown file.
     # First we need to extract the `Tests` section then we extract the fence from within that.
-    with open(os.path.join("samples", sample_filename), "r") as f:
+    with open(sample_path, "r") as f:
         content = f.read()
     tests_re = re.compile(r"^## Tests\n(.*)", re.DOTALL | re.MULTILINE)
     tests_match = tests_re.search(content)
     if tests_match:
         dslx_code = tests_match.group(1).strip()
     else:
-        pytest.skip(f"No tests section found in {sample_filename}")
+        pytest.skip(f"No tests section found in {sample_path}")
     tests_fence_re = re.compile(r"```dslx-snippet(.*?)```", re.DOTALL)
     tests_fence_match = tests_fence_re.search(dslx_code)
     if tests_fence_match:
         dslx_code = tests_fence_match.group(1).strip()
     else:
-        pytest.skip(f"No dslx-snippet fence found in tests section of {sample_filename}")
+        pytest.skip(f"No dslx-snippet fence found in tests section of {sample_path}")
 
     if prologue := try_extract_prologue(content):
         dslx_code = f"{prologue}\n{dslx_code}"
@@ -230,7 +241,7 @@ def test_naive_reference_replacement(sample_filename: str) -> None:
         assert signature_match is not None, f"No function name found in signature: {signature}"
         signature_name = signature_match.group(1)
     else:
-        pytest.skip(f"No dslx-snippet fence found in signature section of {sample_filename}")
+        pytest.skip(f"No dslx-snippet fence found in signature section of {sample_path}")
 
     print(f"Signature name: {signature_name!r}")
 


### PR DESCRIPTION
This change lets eval.py and proc_eval.py run against arbitrary OpenAI-compatible model IDs via --custom-model-slug, adds a small compatibility layer and request overrides for OpenRouter/provider-routed backends, and documents the OpenRouter workflow in docs/openrouter.md so users can easily try hosted models.

It also tightens a few sample critic requirements (count_leading_zeros, integer_sqrt, and prefix_sum) so the benchmark better distinguishes intended algorithmic structure from shortcut implementations.