### PR TITLE
Add #![feature(generics)] to the prologue and prevent from using range function

### DIFF
--- a/eval_shared.py
+++ b/eval_shared.py
@@ -28,6 +28,11 @@ PROMPT_REPLY_SUFFIX = (
     'the (hidden) acceptance test suite. I will respond with any error text '
     'that might occur when running an acceptance test suite.\n'
 )
+# List of prefixes that are added to the prologue (if not present)
+APPEND_PREFIX = [
+    'import std;',
+    '#![feature(generics)]',
+]
 
 
 def load_system_prompt(prompt_file: str | Path) -> str:
@@ -86,12 +91,13 @@ def build_full_code(generated_code: str, sample: Sample, test_file: Path | None)
         for line in prologue.splitlines():
             prologue_lines.append(line.strip())
 
-    has_import_std = (
-        'import std;' in generated_code
-        or any(line.strip() == 'import std;' for line in prologue_lines)
-    )
-    if not has_import_std:
-        prologue_lines.append('import std;')
+    for prefix in APPEND_PREFIX:
+        has_prefix = (
+            prefix in generated_code
+            or any(line.strip() == prefix for line in prologue_lines)
+        )
+        if not has_prefix:
+            prologue_lines.append(prefix)
 
     additional_tests = None
     if test_file:

--- a/prompt.md
+++ b/prompt.md
@@ -394,6 +394,8 @@ fn show_for_loop_with_tuple_accumulator() {
 }
 ```
 
+Note that `range` function is deprecated. Instead of e.g. `range(u32:0, u32:5)` use `u32:0..u32:5`.
+
 **No While Loops** Since functions in DSLX are not turing-complete there are no while loops, everything must be done with bounded loops; i.e. counted `for` loops. This is different from Rust.
 
 **Range Builtin for Iota** To make an array that’s filled with a range of values (sometimes also called “iota”) use exclusive range syntax:


### PR DESCRIPTION
This PR enables `generics` feature, as LLM sometimes tries to use a generic type parameter (like `fn function<T: type>`) which requires the feature.

Also, the prompt is extended to prevent from using deprecated `range` function.